### PR TITLE
ueast1 handling

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -154,7 +154,7 @@ def test_make_request(client, mock_fetch, mock_datetime):
         "header": "blah",
     }
 
-        # Check the rest of the kwargs are correct
+    # Check the rest of the kwargs are correct
     assert kwargs == {"method": "GET", "body": b""}
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -124,35 +124,54 @@ def test_make_request_missing_bucket(client):
 
 
 def test_make_request(client, mock_fetch, mock_datetime):
-        client._make_request(
-            method="GET",
-            path="path/001.gz",
-            headers={"header": "blah"},
-            query_params={"start-at": "abc"},
-            payload=b"",
-            region="us-west-2",
-            bucket="my-bucket",
-        )
+    client._make_request(
+        method="GET",
+        path="path/001.gz",
+        headers={"header": "blah"},
+        query_params={"start-at": "abc"},
+        payload=b"",
+        region="us-west-2",
+        bucket="my-bucket",
+    )
 
-        args, kwargs = mock_fetch.call_args
+    args, kwargs = mock_fetch.call_args
 
-        # Check that the URL is correct
-        host = "my-bucket.s3-us-west-2.amazonaws.com"
-        assert args[0] == "http://" + host + "/path/001.gz?start-at=abc"
-        assert len(args) == 1
+    # Check that the URL is correct
+    host = "my-bucket.s3-us-west-2.amazonaws.com"
+    assert args[0] == "http://" + host + "/path/001.gz?start-at=abc"
+    assert len(args) == 1
 
-        # Check that the headers are correct
-        headers = kwargs.pop("headers")
-        # We don't care about the actual values of these headers, as they're
-        # set by auth code that's tested separately
-        for header in ("x-amz-content-sha256", "Authorization"):
-            headers.pop(header)
+    # Check that the headers are correct
+    headers = kwargs.pop("headers")
+    # We don't care about the actual values of these headers, as they're
+    # set by auth code that's tested separately
+    for header in ("x-amz-content-sha256", "Authorization"):
+        headers.pop(header)
 
-        assert headers == {
-            "host": host,
-            "x-amz-date": mock_datetime.utcnow().strftime(auth.ISO8601_FMT),
-            "header": "blah",
-        }
+    assert headers == {
+        "host": host,
+        "x-amz-date": mock_datetime.utcnow().strftime(auth.ISO8601_FMT),
+        "header": "blah",
+    }
 
         # Check the rest of the kwargs are correct
-        assert kwargs == {"method": "GET", "body": b""}
+    assert kwargs == {"method": "GET", "body": b""}
+
+
+def test_make_request_client(client, mock_fetch, mock_datetime):
+    client._make_request(
+        method="GET",
+        path="path/001.gz",
+        headers={"header": "blah"},
+        query_params={"start-at": "abc"},
+        payload=b"",
+        region="us-east-1",
+        bucket="my-bucket",
+    )
+
+    args, kwargs = mock_fetch.call_args
+
+    # Check that the URL is correct
+    host = "my-bucket.s3.amazonaws.com"
+    assert args[0] == "http://" + host + "/path/001.gz?start-at=abc"
+    assert len(args) == 1

--- a/twisted_s3/client.py
+++ b/twisted_s3/client.py
@@ -8,6 +8,10 @@ from twisted_s3 import response
 from twisted_s3.future import Future
 
 
+US_EAST_TEMPLATE = "{bucket}.s3.amazonaws.com"
+HOST_TEMPLATE = "{bucket}.s3-{region}.amazonaws.com"
+
+
 class S3Client(object):
 
     def __init__(
@@ -53,16 +57,9 @@ class S3Client(object):
 
         hashed_payload = auth.compute_hashed_payload(payload)
 
-        host = ""
-        if region == "us-east-1":
-            host = "{bucket}.s3.amazonaws.com".format(
-                bucket=bucket,
-            )
-        else:
-            host = "{bucket}.s3-{region}.amazonaws.com".format(
-                bucket=bucket,
-                region=region,
-            )
+        host_template = US_EAST_TEMPLATE if region == "us-east-1"\
+            else HOST_TEMPLATE
+        host = host_template.format(bucket=bucket, region=region)
 
         query_string = auth.create_canonical_query_string(query_params)
         if not path.startswith("/"):

--- a/twisted_s3/client.py
+++ b/twisted_s3/client.py
@@ -53,10 +53,17 @@ class S3Client(object):
 
         hashed_payload = auth.compute_hashed_payload(payload)
 
-        host = "{bucket}.s3-{region}.amazonaws.com".format(
-            bucket=bucket,
-            region=region
-        )
+        host = ""
+        if region == "us-east-1":
+            host = "{bucket}.s3.amazonaws.com".format(
+                bucket=bucket,
+            )
+        else:
+            host = "{bucket}.s3-{region}.amazonaws.com".format(
+                bucket=bucket,
+                region=region,
+            )
+
         query_string = auth.create_canonical_query_string(query_params)
         if not path.startswith("/"):
             path = "/" + path


### PR DESCRIPTION
us-east-1 is idiosyncratic and does not follow the usual formulation for s3 endpoints: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

this patch adds special handling for us-east-1
